### PR TITLE
Pin GHAs

### DIFF
--- a/github_actions_workflows/baseline_scans/Endor-Go-Scan-Main.yml
+++ b/github_actions_workflows/baseline_scans/Endor-Go-Scan-Main.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
         
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Setup Go
-          uses: actions/setup-go@v4
+          uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
           with:
             go-version: '1.22.4'
           
@@ -22,7 +22,7 @@ jobs:
           run: go build
           
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/baseline_scans/Endor-Java-Scan-Main.yml
+++ b/github_actions_workflows/baseline_scans/Endor-Java-Scan-Main.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Setup Java
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
           with:
             distribution: microsoft
             java-version: "21"
@@ -23,7 +23,7 @@ jobs:
           run: mvn clean install
             
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/baseline_scans/Endor-JavaScript-Scan-Main.yml
+++ b/github_actions_workflows/baseline_scans/Endor-JavaScript-Scan-Main.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
         
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
         - name: Setup Node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
             node-version: 20
             cache: 'npm'
@@ -25,7 +25,7 @@ jobs:
           run: npm ci
           
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/baseline_scans/Endor-Python-Scan-Main.yml
+++ b/github_actions_workflows/baseline_scans/Endor-Python-Scan-Main.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Set up Python 3.11
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
           with:
             python-version: '3.11'
             cache: 'pip'
@@ -25,7 +25,7 @@ jobs:
             pip install -r requirements.txt
             
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/baseline_scans/Endor-Scan-All-Languages-Main.yml
+++ b/github_actions_workflows/baseline_scans/Endor-Scan-All-Languages-Main.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Set up Python 3.11
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
           with:
             python-version: '3.11'
             cache: 'pip'
@@ -25,7 +25,7 @@ jobs:
             pip install -r requirements.txt
 
         - name: Setup Java
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
           with:
             distribution: microsoft
             java-version: "21"
@@ -34,7 +34,7 @@ jobs:
           run: mvn clean install
 
         - name: Setup Node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
             node-version: 20
             cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
           run: npm ci
 
         - name: Setup Go
-          uses: actions/setup-go@v4
+          uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
           with:
             go-version: '1.22.4'
           
@@ -52,7 +52,7 @@ jobs:
           run: go build
             
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/combined_default_branch_and_pr/endor-cocoapods.yml
+++ b/github_actions_workflows/combined_default_branch_and_pr/endor-cocoapods.yml
@@ -17,19 +17,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
       with:
         ruby-version: "3.3.5"
     - name: Setup CocoaPods
-      uses: maxim-lobanov/setup-cocoapods@v1
+      uses: maxim-lobanov/setup-cocoapods@8e97e1e98e6ccf42564fdf5622c8feec74199377 # v1.4.0
       with:
         podfile-path: Podfile.lock
     - name: Build Package
       run: pod install
     - name: Endor Labs Scan Pull Request
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -50,19 +50,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Ruby
-      uses: ruby/setup-ruby@v1
+      uses: ruby/setup-ruby@1a0ff446f5856bdfec298b61a09727c860d9d480 # v1.240.0
       with:
         ruby-version: "3.3.5"
     - name: Setup CocoaPods
-      uses: maxim-lobanov/setup-cocoapods@v1
+      uses: maxim-lobanov/setup-cocoapods@8e97e1e98e6ccf42564fdf5622c8feec74199377 # v1.4.0
       with:
         podfile-path: Podfile.lock
     - name: Build Package
       run: pod install
     - name: 'Endor Labs Scan Push to main'
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -71,6 +71,6 @@ jobs:
         pr: false
         sarif_file: 'findings.sarif'
     - name: Upload findings to github
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
       with:
         sarif_file: 'findings.sarif'

--- a/github_actions_workflows/combined_default_branch_and_pr/endor-gradle.yml
+++ b/github_actions_workflows/combined_default_branch_and_pr/endor-gradle.yml
@@ -17,18 +17,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'microsoft'
         java-version: '21'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
     - name: Build Package
       run: ./gradlew build
     - name: Endor Labs Scan Pull Request
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -49,18 +49,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'microsoft'
         java-version: '21'
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v4
+      uses: gradle/actions/setup-gradle@748248ddd2a24f49513d8f472f81c3a07d4d50e1 # v4.4.4
     - name: Build Package
       run: ./gradlew build
     - name: 'Endor Labs Scan Push to main'
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -69,6 +69,6 @@ jobs:
         pr: false
         sarif_file: 'findings.sarif'
     - name: Upload findings to github
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
       with:
         sarif_file: 'findings.sarif'

--- a/github_actions_workflows/combined_default_branch_and_pr/endor-mvn.yml
+++ b/github_actions_workflows/combined_default_branch_and_pr/endor-mvn.yml
@@ -17,16 +17,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'microsoft'
         java-version: '21'
     - name: Build Package
       run: mvn clean install
     - name: Endor Labs Scan Pull Request
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -47,16 +47,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         distribution: 'microsoft'
         java-version: '21'
     - name: Build Package
       run: mvn clean install
     - name: 'Endor Labs Scan Push to main'
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -65,6 +65,6 @@ jobs:
         pr: false
         sarif_file: 'findings.sarif'
     - name: Upload findings to github
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
       with:
         sarif_file: 'findings.sarif'

--- a/github_actions_workflows/combined_default_branch_and_pr/endor-npm.yml
+++ b/github_actions_workflows/combined_default_branch_and_pr/endor-npm.yml
@@ -17,15 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '20'
     - name: Build Package
       run: npm install
     - name: Endor Labs Scan Pull Request
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -46,15 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout Repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
     - name: Setup Node
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
       with:
         node-version: '20'
     - name: Build Package
       run: npm install
     - name: 'Endor Labs Scan Push to main'
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'example' # Replace with your Endor Labs tenant namespace
         scan_dependencies: true
@@ -63,6 +63,6 @@ jobs:
         pr: false
         sarif_file: 'findings.sarif'
     - name: Upload findings to github
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@48ab28a6f5dbc2a99bf1e0131198dd8f1df78169 # v3.28.0
       with:
         sarif_file: 'findings.sarif'

--- a/github_actions_workflows/container_scanning_pipelines/Endor-Docker-Container-Scan.yml
+++ b/github_actions_workflows/container_scanning_pipelines/Endor-Docker-Container-Scan.yml
@@ -16,10 +16,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: '21'
         distribution: 'microsoft'
@@ -31,7 +31,7 @@ jobs:
       run: ./gradlew build
 
     - name: Endor Scan
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'arsalan-learn'
         scan_dependencies: true
@@ -42,23 +42,23 @@ jobs:
         log_verbose: true
         
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
     
     - name: Login to Docker Hub
-      uses: docker/login-action@v3
+      uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
       with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           
     - name: Build and push
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@67a2d409c0a876cbe6b11854e3e25193efe4e62d # v6.12.0
       with:
           context: .
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/${{ secrets.DOCKER_REPO }}:your_tag
           
     - name: Scan container
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'arsalan-learn'
         scan_secrets: false

--- a/github_actions_workflows/policy_validation_pipelines/Endor-Validate-Policy-Example.yml
+++ b/github_actions_workflows/policy_validation_pipelines/Endor-Validate-Policy-Example.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Set up Java
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
       with:
         java-version: '21'
         distribution: 'microsoft'
@@ -29,7 +29,7 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y gradle
 
     - name: Endor Scan
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: 'arsalan-learn'
         scan_dependencies: true

--- a/github_actions_workflows/policy_validation_pipelines/Endor-Validate-Policy.yml
+++ b/github_actions_workflows/policy_validation_pipelines/Endor-Validate-Policy.yml
@@ -17,10 +17,10 @@ jobs:
     
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
     - name: Endor Scan
-      uses: endorlabs/github-action@v1.1.4
+      uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
       with:
         namespace: ${{ secrets.ENDOR_NAMESPACE }}
         scan_dependencies: true

--- a/github_actions_workflows/pr_scans/Endor-Go-Scan-PR.yml
+++ b/github_actions_workflows/pr_scans/Endor-Go-Scan-PR.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
         
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Setup Go
-          uses: actions/setup-go@v4
+          uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
           with:
             go-version: '1.22.4'
           
@@ -22,7 +22,7 @@ jobs:
           run: go build
           
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/pr_scans/Endor-Java-Scan-PR.yml
+++ b/github_actions_workflows/pr_scans/Endor-Java-Scan-PR.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
 
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Setup Java
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
           with:
             distribution: microsoft
             java-version: "21"
@@ -25,7 +25,7 @@ jobs:
           run: mvn clean install
             
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/pr_scans/Endor-JavaScript-Scan-PR.yml
+++ b/github_actions_workflows/pr_scans/Endor-JavaScript-Scan-PR.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
         
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
         - name: Setup Node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
             node-version: 20
             cache: 'npm'
@@ -25,7 +25,7 @@ jobs:
           run: npm ci
           
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/pr_scans/Endor-Python-Scan-PR.yml
+++ b/github_actions_workflows/pr_scans/Endor-Python-Scan-PR.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Set up Python 3.11
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
           with:
             python-version: '3.11'
             cache: 'pip'
@@ -25,7 +25,7 @@ jobs:
             pip install -r requirements.txt
             
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/pr_scans/Endor-Scan-All-Languages-PR.yml
+++ b/github_actions_workflows/pr_scans/Endor-Scan-All-Languages-PR.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
 
         - name: Checkout Repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
           
         - name: Set up Python 3.11
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
           with:
             python-version: '3.11'
             cache: 'pip'
@@ -25,7 +25,7 @@ jobs:
             pip install -r requirements.txt
 
         - name: Setup Java
-          uses: actions/setup-java@v4
+          uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4.8.0
           with:
             distribution: microsoft
             java-version: "21"
@@ -34,7 +34,7 @@ jobs:
           run: mvn clean install
 
         - name: Setup Node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
           with:
             node-version: 20
             cache: 'npm'
@@ -44,7 +44,7 @@ jobs:
           run: npm ci
 
         - name: Setup Go
-          uses: actions/setup-go@v4
+          uses: actions/setup-go@7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4 # v4.3.0
           with:
             go-version: '1.22.4'
           
@@ -52,7 +52,7 @@ jobs:
           run: go build
             
         - name: Endor Labs SCA Scan
-          uses: endorlabs/github-action@v1.1.4
+          uses: endorlabs/github-action@802fa65ba7c140405ee52d1c806cfdb647f8f743 # v1.1.4
           with:
             namespace: "matt-demo"
             api: "https://api.endorlabs.com"

--- a/github_actions_workflows/reusable_workflows/js/endorlabs-scan.yml
+++ b/github_actions_workflows/reusable_workflows/js/endorlabs-scan.yml
@@ -10,7 +10,7 @@ jobs:
       project_matrix: ${{ steps.find_projects.outputs.project_matrix }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       # Assumes that all apps are inside an apps folder, and looks for a manifest file
       - name: Discover JS Projects
         id: find_projects

--- a/github_actions_workflows/reusable_workflows/js/endorlabs-single-app-scan.yml
+++ b/github_actions_workflows/reusable_workflows/js/endorlabs-single-app-scan.yml
@@ -46,13 +46,13 @@ jobs:
     runs-on: ${{inputs.runner}}
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Build App
         uses: # Something custom will happen here to build the app
 
       - name: Endor Labs Scan
-        uses: endorlabs/github-action@v1
+        uses: endorlabs/github-action@519df81de5f68536c84ae05ebb2986d0bb1d19fc # v1.1.8
         with:
           namespace: 'my-namespace'
           api_key: ${{ secrets.ENDOR_API_CREDENTIALS_KEY }}

--- a/github_actions_workflows/reusable_workflows/python/endorlabs_scan_py.yml
+++ b/github_actions_workflows/reusable_workflows/python/endorlabs_scan_py.yml
@@ -70,9 +70,9 @@ jobs:
     runs-on: ${{inputs.runner}}
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Set up Python ${{ inputs.python_version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: ${{ inputs.python_version }}
       - name: Process requirements file
@@ -109,7 +109,7 @@ jobs:
           fi
         working-directory: ${{inputs.include_project}}
       - name: Endor Labs Scan
-        uses: endorlabs/github-action@v1
+        uses: endorlabs/github-action@519df81de5f68536c84ae05ebb2986d0bb1d19fc # v1.1.8
         with:
           namespace: 'my-namespace'
           api_key: ${{ secrets.ENDOR_API_CREDENTIALS_KEY }}

--- a/github_actions_workflows/reusable_workflows/python/endorlabs_scan_sample_python_discovery.yml
+++ b/github_actions_workflows/reusable_workflows/python/endorlabs_scan_sample_python_discovery.yml
@@ -11,7 +11,7 @@ jobs:
       uv_projects: ${{ steps.find_projects.outputs.uv_projects }}
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Detect Python Projects with Lockfiles
         id: find_projects


### PR DESCRIPTION
## Summary                                                                              
                                                                                                                                                                                   
  Pin all GitHub Actions to full commit SHAs to prevent supply chain attacks from compromised tags.                                                                                
                                                                                                                                                                                   
  ## Changes                                                                                                                                                                       
                                                                                                                                                                                   
  | Action | Old Ref | New Ref | SHA |                                                                                                                                             
  |--------|---------|---------|-----|
  | actions/checkout | v4 | v4.3.1 | [34e1148](https://github.com/actions/checkout/commit/34e114876b0b11c390a56381ad16ebd13914f8d5) |                                              
  | actions/setup-go | v4 | v4.3.0 | [7b8cf10](https://github.com/actions/setup-go/commit/7b8cf10d4e4a01d4992d18a89f4d7dc5a3e6d6f4) |                                              
  | actions/setup-java | v4 | v4.8.0 | [c1e3236](https://github.com/actions/setup-java/commit/c1e323688fd81a25caa38c78aa6df2d33d3e20d9) |                                          
  | actions/setup-node | v4 | v4.4.0 | [49933ea](https://github.com/actions/setup-node/commit/49933ea5288caeca8642d1e84afbd3f7d6820020) |                                          
  | actions/setup-python | v5 | v5.6.0 | [a26af69](https://github.com/actions/setup-python/commit/a26af69be951a213d495a4c3e4e4022e16d87065) |                                      
  | endorlabs/github-action | v1.1.4 | v1.1.4 | [802fa65](https://github.com/endorlabs/github-action/commit/802fa65ba7c140405ee52d1c806cfdb647f8f743) |                            
  | endorlabs/github-action | v1 | v1.1.8 | [519df81](https://github.com/endorlabs/github-action/commit/519df81de5f68536c84ae05ebb2986d0bb1d19fc) |                                
  | ruby/setup-ruby | v1 | v1.240.0 | [1a0ff44](https://github.com/ruby/setup-ruby/commit/1a0ff446f5856bdfec298b61a09727c860d9d480) |                                              
  | maxim-lobanov/setup-cocoapods | v1 | v1.4.0 | [8e97e1e](https://github.com/maxim-lobanov/setup-cocoapods/commit/8e97e1e98e6ccf42564fdf5622c8feec74199377) |                    
  | gradle/actions | v4 | v4.4.4 | [748248d](https://github.com/gradle/actions/commit/748248ddd2a24f49513d8f472f81c3a07d4d50e1) |                                                  
  | github/codeql-action | v3 | v3.28.0 | [48ab28a](https://github.com/github/codeql-action/commit/48ab28a6f5dbc2a99bf1e0131198dd8f1df78169) |                                     
  | docker/setup-buildx-action | v3 | v3.12.0 | [8d2750c](https://github.com/docker/setup-buildx-action/commit/8d2750c68a42422c14e847fe6c8ac0403b4cbd6f) |                         
  | docker/login-action | v3 | v3.3.0 | [9780b0c](https://github.com/docker/login-action/commit/9780b0c442fbb1117ed29e0efdff1e18412f7567) |                                        
  | docker/build-push-action | v6 | v6.12.0 | [67a2d40](https://github.com/docker/build-push-action/commit/67a2d409c0a876cbe6b11854e3e25193efe4e62d) |                             
                                                                                                                                                                                   
  All pinned commits are at least 90 days old. Original version tags are preserved as inline comments for maintainability.                                                         
                                                                                                                                                                                   
  **Notes:**                                                                                                                                                                       
  - `ruby/setup-ruby@v1` (current HEAD too new, 7 days) — walked back to v1.240.0 (2025-05-16)
  - `github/codeql-action@v3` (current HEAD too new, 7 days) — walked back to v3.28.0 (2024-12-20)                                                                                 
  - `docker/login-action@v3` (current HEAD 66 days old) — walked back to v3.3.0 (2024-07-22)                                                                                       
  - `docker/build-push-action@v6` (current HEAD 50 days old) — walked back to v6.12.0 (2025-01-15)                                                                                 
  - `./.github/workflows/endorlabs-single-app-scan.yml` — local workflow reference, skipped                                                                                        
  - `uses: # Something custom will happen here` — placeholder comment, skipped                                                                                                     
                                                                                                                                                                                   
  **Files modified:**                                                                                                                                                              
  - `.github/workflows/test-trivy-misconfig.yml` — already pinned, no changes                                                                                                      
  - `CI-CD-Examples/github_actions_workflows/baseline_scans/*.yml` — pinned checkout, setup-*, endorlabs actions                                                                   
  - `CI-CD-Examples/github_actions_workflows/combined_default_branch_and_pr/*.yml` — pinned checkout, setup-*, endorlabs, codeql, gradle, ruby, cocoapods actions                  
  - `CI-CD-Examples/github_actions_workflows/container_scanning_pipelines/*.yml` — pinned checkout, setup-java, endorlabs, docker actions                                          
  - `CI-CD-Examples/github_actions_workflows/policy_validation_pipelines/*.yml` — pinned checkout, setup-java, endorlabs actions                                                   
  - `CI-CD-Examples/github_actions_workflows/pr_scans/*.yml` — pinned checkout, setup-*, endorlabs actions                                                                         
  - `CI-CD-Examples/github_actions_workflows/reusable_workflows/**/*.yml` — pinned checkout, setup-python, endorlabs actions  